### PR TITLE
add validate-k8s job

### DIFF
--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
   agent {
     node {
       label 'openstack-slave-pangyo'
+      customWorkspace "workspace/${env.JOB_NAME}/${env.BUILD_NUMBER}"
     }
   }
   environment {
@@ -59,19 +60,31 @@ pipeline {
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "curl -L \"https://github.com/vmware-tanzu/sonobuoy/releases/download/v${version}/sonobuoy_${version}_linux_amd64.tar.gz\" --output ./sonobuoy.tar.gz && tar -xzf ./sonobuoy.tar.gz && chmod +x ./sonobuoy && sudo cp sonobuoy /usr/bin/ && rm -rf ./sonobuoy*"
           """
 
+          sonobuoy_status = sh(returnStatus: true,
+            script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy status'")
+
+          if (!sonobuoy_status) {
+            sh "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy delete --wait'"
+          }
+
           if(params.SONOBUOY_MODE != 'custom' ) {
+            // Pre-defined mode test //
             sh "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} \"sonobuoy run --mode ${params.SONOBUOY_MODE} --e2e-parallel 30 --wait\""
           } else {
-            // Custom Test
+            // Custom Test //
             sh """
               ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy run --e2e-focus='EmptyDir volumes|deployment support rollover|Pods should support retrieving logs|Probing container should be restarted with|Probing container with readiness probe that fails|should update pod when spec was updated|should be consumable|Service endpoints latency|Scaling should happen in predictable order|should perform canary updates|should ensure that all pods are removed|DNS should provide DNS' --e2e-parallel 30 --wait"
             """
           }
 
+          result_file = sh(returnStdout: true,
+            script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy retrieve'").trim()
+
           sh """
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results \$(sonobuoy retrieve)"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results ${result_file}"
             #ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "cat ./results/plugins/e2e/results/global/e2e.log"
           """
+
           result = sh(returnStdout: true,
             script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy status'").trim()
           if(result.contains("failed")) {

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
           println("*** Showing test result ***")
 
           sh """
-            scp ./show_result.sh -i jenkins.key taco@${endpoint}:/home/taco/
+            scp -o StrictHostKeyChecking=no -i jenkins.key validate-k8s/show_result.sh taco@${endpoint}:/home/taco/
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "chmod +x show_result.sh && ./show_result.sh"
           """
 

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -42,6 +42,10 @@ pipeline {
           version = (params.SONOBUOY_VERSION == "latest") ? getUpstreamSonobuoyVersion() : params.SONOBUOY_VERSION
           endpoint = params.KUBERNETES_CLUSTER_IP
 
+          if(!endpoint) {
+            error("Kubernetes Cluster IP was not specified! The value is mandatory!")
+          }
+
           println("============================")
           println("sonobuoy version: ${version}")
           println("cluster endpoint: ${endpoint}")
@@ -82,6 +86,7 @@ pipeline {
 
           sh """
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results ${result_file}"
+            echo "Printing last 100 lines of sonobuoy log..."
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "mkdir ./sonobuoy_result && tar xvf ${result_file} -C ./sonobuoy_result/ && tail -n 100 ./sonobuoy_result/plugins/e2e/results/global/e2e.log"
           """
 

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -86,14 +86,15 @@ pipeline {
 
           sh """
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results ${result_file}"
-            echo "Printing last 100 lines of sonobuoy log..."
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "mkdir ./sonobuoy_result && tar xvf ${result_file} -C ./sonobuoy_result/ && tail -n 100 ./sonobuoy_result/plugins/e2e/results/global/e2e.log"
+
+            echo "Printing failure log..."
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results --mode detailed ${result_file} | jq '. | select(.status == \"failed\") | .details'"
           """
 
           result = sh(returnStdout: true,
             script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy status'").trim()
           if(result.contains("failed")) {
-            throw new Exception("sonobuoy e2e test is failed")
+            throw new Exception("sonobuoy e2e test failed.")
           }
         }
       }

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -64,12 +64,15 @@ pipeline {
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "curl -L \"https://github.com/vmware-tanzu/sonobuoy/releases/download/v${version}/sonobuoy_${version}_linux_amd64.tar.gz\" --output ./sonobuoy.tar.gz && tar -xzf ./sonobuoy.tar.gz && chmod +x ./sonobuoy && sudo cp sonobuoy /usr/bin/ && rm -rf ./sonobuoy*"
           """
 
+          // Check if sonobuoy instance already exists //
           sonobuoy_status = sh(returnStatus: true,
             script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy status'")
 
           if (!sonobuoy_status) {
             sh "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy delete --wait'"
           }
+
+          println("*** Starting sonobuoy test ***")
 
           if(params.SONOBUOY_MODE != 'custom' ) {
             // Pre-defined mode test //
@@ -81,14 +84,11 @@ pipeline {
             """
           }
 
-          result_file = sh(returnStdout: true,
-            script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy retrieve'").trim()
+          println("*** Showing test result ***")
 
           sh """
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results ${result_file}"
-
-            echo "Printing failure log..."
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results --mode detailed ${result_file} | jq '. | select(.status == \"failed\") | .details'"
+            scp ./show_result.sh -i jenkins.key taco@${endpoint}:/home/taco/
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "chmod +x show_result.sh && ./show_result.sh"
           """
 
           result = sh(returnStdout: true,

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -9,7 +9,7 @@ def getUpstreamSonobuoyVersion() {
 pipeline {
   agent {
     node {
-      label 'openstack-slave'
+      label 'openstack-slave-pangyo'
     }
   }
   environment {
@@ -43,7 +43,7 @@ pipeline {
 
           println("============================")
           println("sonobuoy version: ${version}")
-          println("cluster endpoint: ${ip}")
+          println("cluster endpoint: ${endpoint}")
           println("============================")
         }
       }
@@ -57,7 +57,18 @@ pipeline {
             cp /opt/jenkins/.ssh/jenkins-slave-hanukey ./jenkins.key
 
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "curl -L \"https://github.com/vmware-tanzu/sonobuoy/releases/download/v${version}/sonobuoy_${version}_linux_amd64.tar.gz\" --output ./sonobuoy.tar.gz && tar -xzf ./sonobuoy.tar.gz && chmod +x ./sonobuoy && sudo cp sonobuoy /usr/bin/ && rm -rf ./sonobuoy*"
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy run --mode ${params.SONOBUOY_MODE} --e2e-parallel 30 --wait"
+          """
+
+          if(params.SONOBUOY_MODE != 'custom' ) {
+            sh "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} \"sonobuoy run --mode ${params.SONOBUOY_MODE} --e2e-parallel 30 --wait\""
+          } else {
+            // Custom Test
+            sh """
+              ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy run --e2e-focus='EmptyDir volumes|deployment support rollover|Pods should support retrieving logs|Probing container should be restarted with|Probing container with readiness probe that fails|should update pod when spec was updated|should be consumable|Service endpoints latency|Scaling should happen in predictable order|should perform canary updates|should ensure that all pods are removed|DNS should provide DNS' --e2e-parallel 30 --wait"
+            """
+          }
+
+          sh """
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results \$(sonobuoy retrieve)"
             #ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "cat ./results/plugins/e2e/results/global/e2e.log"
           """

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -21,8 +21,8 @@ pipeline {
       defaultValue: 'latest',
       description: 'version of sonobuoy. eg) 0.19.0')
     string(name: 'SONOBUOY_MODE',
-      defaultValue: 'quick',
-      description: 'non-disruptive-conformance | quick | certified-conformance')
+      defaultValue: 'custom',
+      description: 'custom | quick | non-disruptive-conformance | certified-conformance')
     string(name: 'KUBERNETES_CLUSTER_IP',
       defaultValue: '',
       description: 'set exising cluster\'s endpoint. the cluster can be connected with jenkins.key in taco production env. If blank, new aio kubernetes will be deployed to diagnose.')

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -1,0 +1,87 @@
+@Library('jenkins-pipeline-library@main') _
+
+def getUpstreamSonobuoyVersion() {
+  version = sh(returnStdout: true,
+    script: "git ls-remote --tags ${env.SONOBUOY_URL} | awk '{print \$2}' | grep \"v[0-9.]*\$\" | sed \"s/refs\\/tags\\/v//g\" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1").trim()
+  return version
+}
+
+pipeline {
+  agent {
+    node {
+      label 'openstack-slave'
+    }
+  }
+  environment {
+    SONOBUOY_URL = "https://github.com/vmware-tanzu/sonobuoy.git"
+  }
+  parameters {
+    string(name: 'SONOBUOY_VERSION',
+      defaultValue: 'latest',
+      description: 'version of sonobuoy. eg) 0.19.0')
+    string(name: 'SONOBUOY_MODE',
+      defaultValue: 'quick',
+      description: 'non-disruptive-conformance | quick | certified-conformance')
+    string(name: 'KUBERNETES_CLUSTER_IP',
+      defaultValue: '',
+      description: 'set exising cluster\'s endpoint. the cluster can be connected with jenkins.key in taco production env. If blank, new aio kubernetes will be deployed to diagnose.')
+    booleanParam(name: 'CLEANUP',
+      defaultValue: true,
+      description: 'Clean up workspace after job execution')
+  }
+  options {
+    timeout(time: 120, unit: 'MINUTES')
+    timestamps()
+  }
+
+  stages {
+    stage('Init') {
+      steps {
+        script {
+          version = (params.SONOBUOY_VERSION == "latest") ? getUpstreamSonobuoyVersion() : params.SONOBUOY_VERSION
+          endpoint = params.KUBERNETES_CLUSTER_IP
+
+          println("============================")
+          println("sonobuoy version: ${version}")
+          println("cluster endpoint: ${ip}")
+          println("============================")
+        }
+      }
+    }
+
+    stage('Run Sonobuoy') {
+      steps {
+        script {
+          sh """
+            #rm -rf /var/lib/jenkins/.ssh/known_hosts
+            cp /opt/jenkins/.ssh/jenkins-slave-hanukey ./jenkins.key
+
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "curl -L \"https://github.com/vmware-tanzu/sonobuoy/releases/download/v${version}/sonobuoy_${version}_linux_amd64.tar.gz\" --output ./sonobuoy.tar.gz && tar -xzf ./sonobuoy.tar.gz && chmod +x ./sonobuoy && sudo cp sonobuoy /usr/bin/ && rm -rf ./sonobuoy*"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy run --mode ${params.SONOBUOY_MODE} --e2e-parallel 30 --wait"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results \$(sonobuoy retrieve)"
+            #ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "cat ./results/plugins/e2e/results/global/e2e.log"
+          """
+          result = sh(returnStdout: true,
+            script: "ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} 'sonobuoy status'").trim()
+          if(result.contains("failed")) {
+            throw new Exception("sonobuoy e2e test is failed")
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      script {
+        if ( params.CLEANUP == true ) {
+          sh """
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy delete --all --wait"
+          """
+        } else {
+          echo "Skipping sonobuoy cleanup.."
+        }
+      }
+    }
+  }
+}

--- a/validate-k8s/Jenkinsfile
+++ b/validate-k8s/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
 
           sh """
             ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy results ${result_file}"
-            #ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "cat ./results/plugins/e2e/results/global/e2e.log"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "mkdir ./sonobuoy_result && tar xvf ${result_file} -C ./sonobuoy_result/ && tail -n 100 ./sonobuoy_result/plugins/e2e/results/global/e2e.log"
           """
 
           result = sh(returnStdout: true,
@@ -100,7 +100,7 @@ pipeline {
       script {
         if ( params.CLEANUP == true ) {
           sh """
-            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy delete --all --wait"
+            ssh -o StrictHostKeyChecking=no -i jenkins.key taco@${endpoint} "sonobuoy delete --all --wait && rm -rf ./sonobuoy_result"
           """
         } else {
           echo "Skipping sonobuoy cleanup.."

--- a/validate-k8s/README.md
+++ b/validate-k8s/README.md
@@ -1,0 +1,11 @@
+# Validate-k8s 
+본 job은 기존에 배포가 완료된 k8s cluster에 대해, sonobuoy라는 테스트 툴을 사용하여 일련을 테스트들을 수행함으로써 클러스터가 정상적으로 동작하는지 검증하는 job이다 
+
+## Job Parameter
+TBU
+
+
+## Test mode
+TBU
+
+

--- a/validate-k8s/README.md
+++ b/validate-k8s/README.md
@@ -1,11 +1,37 @@
 # Validate-k8s 
-본 job은 기존에 배포가 완료된 k8s cluster에 대해, sonobuoy라는 테스트 툴을 사용하여 일련을 테스트들을 수행함으로써 클러스터가 정상적으로 동작하는지 검증하는 job이다 
+본 job은 기존에 배포가 완료된 k8s cluster에 대해, sonobuoy라는 테스트 툴을 사용하여 일련을 테스트들을 수행함으로써 클러스터가 정상적으로 동작하는지 검증하는 job이다. 
 
 ## Job Parameter
-TBU
+* SONOBUOY_VERSION: sonobuoy version (default: latest)
+* SONOBUOY_MODE: test mode를 선택할 수 있으며 mode 종류는 다음과 같다.
+  * custom: 미리 정의된 10 여가지의 주요 테스트를 수행 ('quick'과 'non-disruptive-conformance'의 중간 정도의 커버리지를 가짐. Default mode)
+  * quick: pod를 생성하고 삭제하는 등 매우 간단한 single test를 수행.
+  * non-disruptive-conformance: 클러스터 내의 다른 워크로드를 방해하지 않는 범위에서, Conformance(적합성)로 표시된 모든 테스트를 실행.
+  * certified-conformance: 모든 적합성 테스트를 실행하며 Certified Kubernetes Conformance Program을 신청할 때 사용되는 모드이다. 이러한 테스트 중 일부는 클러스터 내의 다른 워크로드에 지장을 줄 수 있으므로 주의가 필요하다.
+* KUBERNETES_CLUSTER_IP: 테스트의 대상이 될 kubernetes cluster의 API endpoint IP
 
+## Test Result
+테스트가 완료된 후 Jenkins console 상에서 다음과 같이 결과를 확인할 수 있다.
+테스트 통계를 요약해서 보여주며, 실패한 케이스에 대해 상세로그를 표시해준다.
+아래 예시의 경우는, 실제 테스트 케이스 수행 이전에 사전 체크에서 실패하여 total case 숫자가 1로 표시되어 있으며, 실제로는 더 큰 수치가 표시될 수 있다.
+```
+Plugin: e2e
+Status: failed
+Total: 1
+Passed: 0
+Failed: 1
+Skipped: 0
 
-## Test mode
-TBU
+Failed tests:
+BeforeSuite
 
-
+Plugin: systemd-logs
+Status: passed
+Total: 1
+Passed: 1
+Failed: 0
+Skipped: 0
+{
+  "failure": "_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:71\nFeb 10 07:01:28.601: Error waiting for all pods to be running and ready: 1 / 12 pods in namespace \"kube-system\" are NOT in RUNNING and READY state in 10m0s\nPOD                    NODE PHASE   GRACE CONDITIONS\ncoredns-dff8fc7d-765qt      Pending       [{Type:PodScheduled Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-02-09 07:28:57 +0000 UTC Reason:Unschedulable Message:0/1 nodes are available: 1 node(s) didn't match pod affinity/anti-affinity, 1 node(s) didn't satisfy existing pods anti-affinity rules.}]\n\n_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:279"
+}
+```

--- a/validate-k8s/show_result.sh
+++ b/validate-k8s/show_result.sh
@@ -2,4 +2,4 @@
 
 result_file=$(sonobuoy retrieve)
 sonobuoy results $result_file
-sonobuoy results --mode detailed $result_file |  jq '. | select(.status == "failed") | .details'
+sonobuoy results --mode detailed $result_file |  jq '. | select(.status == "failed") | .details' || true

--- a/validate-k8s/show_result.sh
+++ b/validate-k8s/show_result.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+result_file=$(sonobuoy retrieve)
+sonobuoy results $result_file
+sonobuoy results --mode detailed $result_file |  jq '. | select(.status == "failed") | .details'


### PR DESCRIPTION
deploy-taco job을 통해 k8s를 배포한 후, 클러스터가 정상동작하는지 검증하는 절차가 필요하다. 
이를 위해 sonobuoy라는 k8s test 툴을 사용하여 k8s가 정상적으로 동작하는지 테스트하는 'validate-k8s'라는 job을 Jenkins에 추가함.