### PR TITLE
get Elasticsearch NodePort using kubectl

### DIFF
--- a/validate-lma/Jenkinsfile
+++ b/validate-lma/Jenkinsfile
@@ -50,10 +50,12 @@ pipeline {
           sh """
             ssh -o StrictHostKeyChecking=no -i /opt/jenkins/.ssh/jenkins-slave-hanukey taco@${endpoint} "curl -L \"https://github.com/jabbukka/efk-e2e-tests/releases/download/${version}/efk-e2e-runner-${version}-linux-amd64.tar.gz\" --output ./efk-e2e-runner.tar.gz && tar -xzf ./efk-e2e-runner.tar.gz && chmod +x ./efk-e2e-runner && sudo cp efk-e2e-runner /usr/bin/ && rm -rf ./efk-e2e-runner*"
           """
+          esPort = sh(returnStdout: true,
+               script: "ssh -o StrictHostKeyChecking=no -i /opt/jenkins/.ssh/jenkins-slave-hanukey taco@${endpoint} \"kubectl get svc eck-elasticsearch-es-http -nlma -ojsonpath={'.spec.ports[0].nodePort'}\"").trim()
 
           println("*** Starting efk e2e test ***")
           sh """
-            ssh -o StrictHostKeyChecking=no -i /opt/jenkins/.ssh/jenkins-slave-hanukey taco@${endpoint} "efk-e2e-runner -kibana-host \"http://${endpoint}:30001\" -es-host \"https://${endpoint}:30002\""
+            ssh -o StrictHostKeyChecking=no -i /opt/jenkins/.ssh/jenkins-slave-hanukey taco@${endpoint} "efk-e2e-runner -kibana-host \"http://${endpoint}:30001\" -es-host \"https://${endpoint}:${esPort}\""
           """
         }
       }


### PR DESCRIPTION
* nodePort는 고정 값이 아닌 유동적으로 변하는 값이기 때문에 kubectl 명령어를 통해서 가져온다.
* 성공한 Jenkins job link: https://jenkins.hanu-ci.io/job/validate-lma/23/console