### PR TITLE
add build-capi-images job

### DIFF
--- a/build-capi-images/Jenkinsfile
+++ b/build-capi-images/Jenkinsfile
@@ -1,0 +1,70 @@
+@Library('jenkins-pipeline-library@main') _
+
+pipeline {
+  agent {
+    node {
+      label 'openstack-slave-pangyo-ubuntu'
+      customWorkspace "workspace/${env.JOB_NAME}/${env.BUILD_NUMBER}"
+    }
+  }
+  environment {
+    IMAGEBUILDER_URL = "https://github.com/kubernetes-sigs/image-builder.git"
+  }
+  parameters {
+    string(name: 'UBUNTU_VERSION',
+      defaultValue: '2004',
+      description: 'Ubuntu version')
+    string(name: 'K8S_VERSION_MAJOR_MINOR',
+      defaultValue: '1.20',
+      description: 'Kubernetes version MAJOR.MINOR.z')
+    string(name: 'K8S_VERSION_PATCH',
+      defaultValue: '2',
+      description: 'Kubernetes version x.y.PATCH')
+  }
+  options {
+    timeout(time: 120, unit: 'MINUTES')
+    timestamps()
+  }
+
+  stages {
+    stage ('Init') {
+      steps {
+        script {
+	  ubuntu_version = params.UBUNTU_VERSION
+	  k8s_series = params.K8S_VERSION_MAJOR_MINOR
+	  k8s_version = params.K8S_VERSION_MAJOR_MINOR + "." + params.K8S_VERSION_PATCH
+
+          println("============================")
+          println("Ubuntu version: ${ubuntu_version}")
+          println("Kubernetes version: ${k8s_series}, ${k8s_version}")
+          println("============================")
+
+	  sh """
+            git clone ${env.IMAGEBUILDER_URL}
+
+            # Use cloud-init's growroot
+            sed -i '/cloud-initramfs-growroot/d' image-builder/images/capi/ansible/roles/providers/tasks/qemu.yml
+
+            build-capi-images/preserving_resolv_conf.sh
+            build-capi-images/create_packer_tmpl.sh ${k8s_version}
+            build-capi-images/prepare_local_iso.sh image-builder/images/capi/packer/qemu/qemu-ubuntu-${ubuntu_version}.json
+
+	    cd image-builder/images/capi/
+            PACKER_VAR_FILES=../../../packer_taco.json make build-qemu-ubuntu-${ubuntu_version}
+
+            /snap/bin/openstack --os-cloud=pangyo-prd image create --disk-format raw --container-format bare --public --file output/ubuntu-${ubuntu_version}-kube-v${k8s_version}/ubuntu-${ubuntu_version}-kube-v${k8s_version} ubuntu-${ubuntu_version}-kube-v${k8s_version}-\$(date +%F)
+	  """
+        }
+      }
+    }
+  }
+
+  post {
+    success {
+      notifyCompleted(true)
+    }
+    failure {
+      notifyCompleted(false)
+    }
+  }
+}

--- a/build-capi-images/README.md
+++ b/build-capi-images/README.md
@@ -1,0 +1,13 @@
+# buildCAPIImages
+
+Cluster-API 노드를 위한 이미지 생성을 수행한다.
+
+## Job Parameter
+* UBUNTU_VERSION: 기본 Ubuntu 리눅스 버전을 지정한다, 예) 2004, 1804
+* K8S_VERSION_MAJOR_MINOR: 사용하고자 하는 Kubernetes 버전의 Major.Minor를 지정한다, 예) 1.20
+* K8S_VERSION_PATCH: 사용하고자 하는 Kubernetes 버전의 Patch 번호를 지정한다, 예) 2
+
+## 참고
+[image-builder](https://github.com/kubernetes-sigs/image-builder)를 사용하며 아래와 같은 변경 사항이 존재한다.
+* Ubuntu에서 growroot를 initramfs가 아닌 cloud-init에서 구동
+* Ubuntu의 systemd-resolved를 /etc/resolv.conf를 보존하는 모드로 사용 (https://wiki.archlinux.org/index.php/Systemd-resolved#DNS)

--- a/build-capi-images/create_packer_tmpl.sh
+++ b/build-capi-images/create_packer_tmpl.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -ex
+
+if [ -z "$1" ]
+then
+    K8S_VERSION="1.20.2"
+else
+    K8S_VERSION=$1
+fi
+
+K8S_SERIES=$(echo ${K8S_VERSION} | awk -F'.' '{print $1"."$2}')
+
+cat << EOF > ./packer_taco.json
+{
+  "kubernetes_series": "v${K8S_SERIES}",
+  "kubernetes_semver": "v${K8S_VERSION}",
+  "kubernetes_deb_version": "${K8S_VERSION}-00",
+  "disk_size": "5240",
+  "format": "raw",
+  "iso_url": "\$ISO_LOCAL"
+}
+EOF

--- a/build-capi-images/prepare_local_iso.sh
+++ b/build-capi-images/prepare_local_iso.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -ex
+
+PACKER_OS_TARGET=$1
+
+ISO_URL=$(jq -r .iso_url $PACKER_OS_TARGET)
+ISO_FILENAME=$(echo ${ISO_URL##*/})
+ISO_LOCAL="/home/jenkins/cdimages/${ISO_FILENAME}"
+
+ISO_CHECKSUM_ORIG=$(jq -r .iso_checksum $PACKER_OS_TARGET)
+ISO_CHECKSUM_TYPE=$(jq -r .iso_checksum_type $PACKER_OS_TARGET)
+ISO_CHECKSUM_EXEC="${ISO_CHECKSUM_TYPE}sum"
+
+if [ ! -f "$ISO_LOCAL" ]; then
+        echo "Downloading $ISO_LOCAL"
+        curl $ISO_URL --output $ISO_LOCAL
+fi
+
+ISO_CHECKSUM_LOCAL=$($ISO_CHECKSUM_EXEC $ISO_LOCAL | awk '{print $1}')
+if [ $ISO_CHECKSUM_ORIG != $ISO_CHECKSUM_LOCAL ]; then
+        echo "ISO checksum was different. Something wrong!"
+        exit 1
+fi
+
+ISO_LOCAL=${ISO_LOCAL} envsubst < packer_taco.json > packer_taco_tmp.json
+mv packer_taco_tmp.json packer_taco.json

--- a/build-capi-images/preserving_resolv_conf.sh
+++ b/build-capi-images/preserving_resolv_conf.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -ex
+
+cat << EOF >> image-builder/images/capi/ansible/roles/providers/tasks/qemu.yml
+
+- name: Symlink /run/systemd/resolve/resolv.conf to /etc/resolv.conf
+  file:
+    src:   /run/systemd/resolve/resolv.conf
+    dest:  /etc/resolv.conf
+    mode: 0644
+    state: link
+    force: yes
+  when: ansible_os_family == "Debian"
+EOF


### PR DESCRIPTION
Cluster-API의 노드에서 사용할 이미지를 생성하는 Job 입니다. 현재 기본 설정은 Ubuntu 20.04 w/ K8S 1.20.2 입니다.

 