### PR TITLE
Remove kube-scheduler and controller manager from default check

### DIFF
--- a/validate-lma/check_prometheus.py
+++ b/validate-lma/check_prometheus.py
@@ -7,9 +7,9 @@ CHECK_INTERVAL=30
 targets = ["kubernetes",
     "kube-state-metrics",
     "lma-coredns",
-    "lma-kube-controller-manager",
+    # "lma-kube-controller-manager",
     "lma-kube-proxy",
-    "lma-kube-scheduler",
+    # "lma-kube-scheduler",
     "lma-prometheus",
     "process-exporter",
     "prometheus-node-exporter",
@@ -68,7 +68,7 @@ def main(argv):
       timeout = int(arg)
 
   print(url)
-  while targets:
+  while True:
     checked=[]
     for target in targets:
       if check_up(url, target):
@@ -79,11 +79,13 @@ def main(argv):
     for target in checked:
       targets.remove(target)
 
+    if not targets:
+        sys.exit(0)
     print(targets, "are not checked. Sleeping for",CHECK_INTERVAL,". Timeout(", timeout, ") is left before terminate with fail.")
     time.sleep(CHECK_INTERVAL)
     timeout = timeout-CHECK_INTERVAL
     if timeout<0:
-      sys.exit(targets, "are not checked. (finished with fail)")
+        sys.exit("{} are not checked. (finished with fail)".format(target))
 
 if __name__ == "__main__":
   main(sys.argv[1:])


### PR DESCRIPTION
TLS를 사용하는 위 두개의 타겟에서 현재 구성으로는 매트릭을 수집하지 못함
따라서 테스트에서 두개를 빼려함