### PR TITLE
build-capi-image: make cloud-init manage /etc/hosts

### DIFF
--- a/build-capi-images/Jenkinsfile
+++ b/build-capi-images/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
             sed -i '/cloud-initramfs-growroot/d' image-builder/images/capi/ansible/roles/providers/tasks/qemu.yml
 
             build-capi-images/preserving_resolv_conf.sh
+            build-capi-images/manage_etc_hosts.sh
             build-capi-images/create_packer_tmpl.sh ${k8s_version}
             build-capi-images/prepare_local_iso.sh image-builder/images/capi/packer/qemu/qemu-ubuntu-${ubuntu_version}.json
 

--- a/build-capi-images/manage_etc_hosts.sh
+++ b/build-capi-images/manage_etc_hosts.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+cat << EOF >> image-builder/images/capi/ansible/roles/providers/tasks/qemu.yml
+
+- name: Make cloud-init manage /etc/hosts
+  lineinfile:
+    path: /etc/cloud/cloud.cfg
+    line: 'manage_etc_hosts: True'
+  when: ansible_os_family == "Debian"
+EOF


### PR DESCRIPTION
CAPI로 생성된 VM에서 sudo 와 같은 명령어를 사용할 때 아래처럼 오류 메세지가 발생합니다.
 - "unable to resolve host {hostname}: Name or service not known"
/etc/hosts에 노도의 호스트네임에 대한 항목이 없어서 발생하는 것으로 cloud-init이 /etc/hosts를 관리하도록 설정하였습니다.