### PR TITLE
Add preparation inventory from taco-gate-inventories

### DIFF
--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
               yum install -y git iproute net-tools
               git clone https://github.com/openinfradev/tacoplay.git
               cp -r inventories/${params.TARGET_SITE} tacoplay/inventory/
+              cp -r inventories/preparation tacoplay/inventory
               mkdir ~/agent/docker_images || true
             """
 


### PR DESCRIPTION
prepartion inventory 추가
용도: site-prepare 실행 시 필요한 local 설치용 inventory
