### PR TITLE
Download helmchart

### DIFF
--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                 pip install --upgrade pip
                 pip install -r requirements.txt
 
-                ansible-playbook -vvv -u root -b -i inventory/preparation/local.ini extra-playbooks/site-prepare.yml --tags download,upload,preinstall,untagged --skip-tags upgrade -e @inventory/preparation/extra-vars.yml ${tacoplay_params}
+                ansible-playbook -vvv -u root -b -i inventory/preparation/local.ini extra-playbooks/site-prepare.yml --tags download,upload,preinstall,untagged --skip-tags upgrade -e @inventory/preparation/extra-vars.yml -e site_name=${params.TARGET_SITE} ${tacoplay_params}
               """
             }
           }

--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     ANSIBLE_INVALID_TASK_ATTRIBUTE_FAILED = "False"
   }
   options {
-    timeout(time: 120, unit: 'MINUTES')
+    timeout(time: 240, unit: 'MINUTES')
     timestamps()
   }
 

--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -49,10 +49,22 @@ pipeline {
               git clone https://github.com/openinfradev/tacoplay.git
               cp -r inventories/${params.TARGET_SITE} tacoplay/inventory/
               mkdir ~/agent/docker_images || true
-            """
+              #FIXME: delete branch option after test
+              git clone -b test-download-helm-chart https://github.com/openinfradev/decapod-site-yaml.git
 
+            """
             dir('tacoplay') {
               sh "git checkout ${params.TACOPLAY_VERSION}"
+            }
+            dir('decapod-site-yaml') {
+              def app_list = params.INCLUDED_APPS.split(',')
+              app_list.each{
+                sh ".github/workflows/render.sh ${it}"
+                sh "cp ${it}/output/${params.TARGET_SITE}/${it}-manifest.yaml ${env.WORKSPACE}/tacoplay/inventory/preparation/"
+              }
+            }
+            dir('tacoplay') {
+              //sh "git checkout ${params.TACOPLAY_VERSION}"
 
               // Should pass this format: '{"taco_apps": ['openstack','lma']}'
               tacoplay_params = "-e '{\"taco_apps\": ["
@@ -63,14 +75,10 @@ pipeline {
 
                 app_list.eachWithIndex { app, index ->
                   if ( app == 'openstack') {
-                    if (params.TARGET_SITE.startsWith('gate')) {
-                      sh "cp ./inventory/${params.TARGET_SITE}/${app}-manifest.yaml ./inventory/preparation/"
-                    } else {
+                    if (! params.TARGET_SITE.startsWith('gate')) {
                       add_openstack_param = true
                     }
-                  } else {
-                    sh "cp ./inventory/${params.TARGET_SITE}/${app}-manifest.yaml ./inventory/preparation/"
-                  }
+                  } 
 
                   if ( index == app_list.length-1 ) {
                     tacoplay_params += "'${app}'"

--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -82,6 +82,13 @@ pipeline {
               }
 
               println("tacoplay_params: ${tacoplay_params}")
+              repo = sh (
+                script: "cat /etc/hosts|grep tacorepo",
+                returnStatus: true
+              ) 
+              if ( repo == 1 ) {
+                sh (script: "echo 127.0.0.1 tacorepo|tee -a /etc/hosts")
+              }
 
               sh """
                 env | grep PATH

--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       defaultValue: 'gate-centos-lb-ceph-online-multinodes',
       description: 'target site (inventory) name for manifest preparation')
     string(name: 'INCLUDED_APPS',
-      defaultValue: 'openstack,lma',
+      defaultValue: 'openstack,lma,service-mesh',
       description: 'Apps to include in tarball? (comma-separated list)')
     string(name: 'OPENSTACK_RELEASE',
       defaultValue: 'stein',

--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -49,22 +49,10 @@ pipeline {
               git clone https://github.com/openinfradev/tacoplay.git
               cp -r inventories/${params.TARGET_SITE} tacoplay/inventory/
               mkdir ~/agent/docker_images || true
-              #FIXME: delete branch option after test
-              git clone -b test-download-helm-chart https://github.com/openinfradev/decapod-site-yaml.git
 
             """
             dir('tacoplay') {
               sh "git checkout ${params.TACOPLAY_VERSION}"
-            }
-            dir('decapod-site-yaml') {
-              def app_list = params.INCLUDED_APPS.split(',')
-              app_list.each{
-                sh ".github/workflows/render.sh ${it}"
-                sh "cp ${it}/output/${params.TARGET_SITE}/${it}-manifest.yaml ${env.WORKSPACE}/tacoplay/inventory/preparation/"
-              }
-            }
-            dir('tacoplay') {
-              //sh "git checkout ${params.TACOPLAY_VERSION}"
 
               // Should pass this format: '{"taco_apps": ['openstack','lma']}'
               tacoplay_params = "-e '{\"taco_apps\": ["


### PR DESCRIPTION
1. tacoplay의 site-prepare 플레이북을 호출할 때 decapod-site-yaml에서 Helm release manifest yaml을 추출하여 helm chart와 container image를 다운로드하기 위해 site_name 파라미터를 추가한다.
2. docker push로 이미지가 local repo에 저장되도록 local repo를 /etc/hosts에 추가한다.
3. hanu 환경을 고려해 타임아웃 시간을 2시간에서 4시간으로 변경한다.