### PR TITLE
don't use target inventory

### DIFF
--- a/site-prepare/Jenkinsfile
+++ b/site-prepare/Jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
               cp /root/.netrc ~/.netrc
               yum install -y git iproute net-tools
               git clone https://github.com/openinfradev/tacoplay.git
-              cp -r inventories/${params.TARGET_SITE} tacoplay/inventory/
               cp -r inventories/preparation tacoplay/inventory
               mkdir ~/agent/docker_images || true
 


### PR DESCRIPTION
since decapod manifest is fetched directly from git repo